### PR TITLE
minifyJS options are removed from ember-cli 0.1.15

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,9 +77,8 @@ InlineContentRenderer.prototype.renderContentWithTag = function(content, tag, op
 
 InlineContentRenderer.prototype.renderScript = function(content, options) {
   if (this.options.minifyJS.enabled) {
-    var uglifyOptions = this.options.minifyJS.options;
-    uglifyOptions.fromString = true;
-    content = UglifyJS.minify(content, this.options.minifyJS.options).code;
+    var uglifyOptions = { fromString: true };
+    content = UglifyJS.minify(content, uglifyOptions).code;
   }
   return this.renderContentWithTag(content, 'script', options);
 };


### PR DESCRIPTION
As part of the sourcemap work, `this.options.minifyJS.options` got removed. This fixes a crasher when running on ember-cli HEAD (and when 0.1.15 eventually gets released).
